### PR TITLE
Added a test case for truncated messages

### DIFF
--- a/position.go
+++ b/position.go
@@ -316,8 +316,14 @@ func (body Info) Position() (Position, error) {
 	switch body.Type() {
 	case '!', '=':
 		t := string(body)
+		if len(body) < 2 {
+			return Position{}, ErrTruncatedMsg
+		}
 		return newParser(t[1:], unicode.IsDigit(rune(t[1])))
 	case '/', '@':
+		if len(body) < 9 {
+			return Position{}, ErrTruncatedMsg
+		}
 		t := string(body[8:])
 		return newParser(t, unicode.IsDigit(rune(body[8])))
 	case ';':

--- a/position_test.go
+++ b/position_test.go
@@ -1,6 +1,9 @@
 package aprs
 
-import "testing"
+import (
+	"fmt"
+	"testing"
+)
 
 func TestSymbol(t *testing.T) {
 	tests := []struct {
@@ -58,5 +61,24 @@ func TestPositionParsing(t *testing.T) {
 	if err == nil {
 		t.Errorf("Expected error on three bytes uncompressed, got %v", x)
 	}
+}
 
+func TestInvalidPosition(t *testing.T) {
+	testBodies := []string{
+		"@",
+		"@1234568",
+		"!",
+		"!1",
+		";",
+		";123456789012345678",
+	}
+	for i, testFrame := range testBodies {
+		t.Run(fmt.Sprintf("InvalidPosition[%d]", i), func(t *testing.T) {
+			parsedFrame := ParseFrame("SOURCE>DESTINATION,PATH:" + testFrame)
+			_, err := parsedFrame.Body.Position()
+			if err == nil {
+				t.Fatalf("Parsing %q: expecting any error, go not error", testFrame)
+			}
+		})
+	}
 }


### PR DESCRIPTION
This PR will prevent the library to crash when the message is truncated.